### PR TITLE
Add extend and split methods to Semaphore guards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ version-sync = "0.9"
 lazy_static = "1.4.0"
 tokio = { version = "0.2", features = ["full"] }
 futures-locks = "0.6.0"
+tokio-test = "0.2"
 
 [dev-dependencies.futures]
 version = "0.3.5"

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -31,10 +31,37 @@ pub struct SemaphoreGuardArc {
     panicking: bool,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SemaphoreGuardSplitErr {
+    Underflow
+}
+
 impl<'a> SemaphoreGuard<'a> {
     pub fn new(semaphore: &'a Semaphore, amount: usize) -> Self {
         SemaphoreGuard { semaphore, amount, panicking: panicking() }
     }
+
+    /// Combine two `SemaphoreGuard`s into one, with the sum of the originals' permits.
+    ///
+    /// # Examples
+    /// ```
+    /// # use async_weighted_semaphore::Semaphore;
+    /// # tokio_test::block_on(async {
+    /// let semaphore = Semaphore::new(15);
+    /// let mut g1 = semaphore.acquire(10).await.unwrap();
+    /// let g2 = semaphore.acquire(5).await.unwrap();
+    /// g1.extend(g2);
+    /// # })
+    /// ```
+    pub fn extend(&mut self, other: SemaphoreGuard<'a>) {
+        if std::ptr::eq(self.semaphore, other.semaphore) {
+            self.amount += other.forget();
+        } else {
+            self.semaphore.poison();
+            other.semaphore.poison();
+        }
+    }
+
     /// Drop the guard without calling [`Semaphore::release`]. This is useful when `release`s don't
     /// correspond one-to-one with `acquires` or it's difficult to send the guard to the releaser.
     /// # Examples
@@ -63,12 +90,63 @@ impl<'a> SemaphoreGuard<'a> {
         mem::forget(self);
         amount
     }
+
+    /// Split this `SemaphoreGuard` into two.
+    ///
+    /// The new guard will have `permits` permits, and this guard's permits will be reduced
+    /// accordingly.
+    ///
+    /// # Examples
+    /// ```
+    /// # use async_weighted_semaphore::Semaphore;
+    /// # tokio_test::block_on(async {
+    /// let semaphore = Semaphore::new(15);
+    /// let mut g1 = semaphore.acquire(15).await.unwrap();
+    /// let g2 = g1.split(5).unwrap();
+    /// # })
+    /// ```
+    pub fn split(&mut self, permits: usize) -> Result<SemaphoreGuard<'a>, SemaphoreGuardSplitErr> {
+        if self.amount >= permits {
+            self.amount -= permits;
+            Ok(SemaphoreGuard {
+                semaphore: self.semaphore.clone(),
+                amount: permits,
+                panicking: self.panicking
+            })
+        } else {
+            Err(SemaphoreGuardSplitErr::Underflow)
+        }
+    }
 }
 
 impl SemaphoreGuardArc {
     pub fn new(semaphore: Arc<Semaphore>, amount: usize) -> Self {
         SemaphoreGuardArc { semaphore: Some(semaphore), amount, panicking: panicking() }
     }
+
+    /// Combine two `SemaphoreGuardArc`s into one, with the sum of the originals' permits.
+    ///
+    /// # Examples
+    /// ```
+    /// # use async_weighted_semaphore::Semaphore;
+    /// # tokio_test::block_on(async {
+    /// let semaphore = Semaphore::new(15);
+    /// let mut g1 = semaphore.acquire_arc(10).await.unwrap();
+    /// let g2 = semaphore.acquire_arc(5).await.unwrap();
+    /// g1.extend(g2);
+    /// # })
+    /// ```
+    pub fn extend(&mut self, other: SemaphoreGuardArc) {
+        let sem1 = self.semaphore.as_ref().unwrap();
+        let sem2 = other.semaphore.as_ref().unwrap();
+        if Arc::ptr_eq(sem1, sem2) {
+            self.amount += other.forget();
+        } else {
+            sem1.poison();
+            sem2.poison();
+        }
+    }
+
     /// Drop the guard without calling [`Semaphore::release`]. This is useful when `release`s don't
     /// correspond one-to-one with `acquires` or it's difficult to send the guard to the releaser.
     /// # Examples
@@ -98,6 +176,33 @@ impl SemaphoreGuardArc {
         let amount = self.amount;
         mem::forget(self);
         amount
+    }
+
+    /// Split this `SemaphoreGuardArc` into two.
+    ///
+    /// The new guard will have `permits` permits, and this guard's permits will be reduced
+    /// accordingly.
+    ///
+    /// # Examples
+    /// ```
+    /// # use async_weighted_semaphore::Semaphore;
+    /// # tokio_test::block_on(async {
+    /// let semaphore = Arc::new(Semaphore::new(15));
+    /// let mut g1 = semaphore.acquire_arc(15).await.unwrap();
+    /// let g2 = g1.split(5).unwrap();
+    /// # })
+    /// ```
+    pub fn split(&mut self, permits: usize) -> Result<SemaphoreGuardArc, SemaphoreGuardSplitErr> {
+        if self.amount >= permits {
+            self.amount -= permits;
+            Ok(SemaphoreGuardArc {
+                semaphore: self.semaphore.clone(),
+                amount: permits,
+                panicking: self.panicking
+            })
+        } else {
+            Err(SemaphoreGuardSplitErr::Underflow)
+        }
     }
 }
 

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -54,12 +54,9 @@ impl<'a> SemaphoreGuard<'a> {
     /// # })
     /// ```
     pub fn extend(&mut self, other: SemaphoreGuard<'a>) {
-        if std::ptr::eq(self.semaphore, other.semaphore) {
-            self.amount += other.forget();
-        } else {
-            self.semaphore.poison();
-            other.semaphore.poison();
-        }
+        assert!(std::ptr::eq(self.semaphore, other.semaphore),
+            "Can't extend a guard with a guard from a different Semaphore");
+        self.amount += other.forget();
     }
 
     /// Drop the guard without calling [`Semaphore::release`]. This is useful when `release`s don't
@@ -139,12 +136,9 @@ impl SemaphoreGuardArc {
     pub fn extend(&mut self, other: SemaphoreGuardArc) {
         let sem1 = self.semaphore.as_ref().unwrap();
         let sem2 = other.semaphore.as_ref().unwrap();
-        if Arc::ptr_eq(sem1, sem2) {
-            self.amount += other.forget();
-        } else {
-            sem1.poison();
-            sem2.poison();
-        }
+        assert!(Arc::ptr_eq(sem1, sem2),
+            "Can't extend a guard with a guard from a different Semaphore");
+        self.amount += other.forget();
     }
 
     /// Drop the guard without calling [`Semaphore::release`]. This is useful when `release`s don't

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -56,7 +56,7 @@ impl<'a> SemaphoreGuard<'a> {
     pub fn extend(&mut self, other: SemaphoreGuard<'a>) {
         assert!(std::ptr::eq(self.semaphore, other.semaphore),
             "Can't extend a guard with a guard from a different Semaphore");
-        self.amount += other.forget();
+        self.amount = self.amount.saturating_add(other.forget());
     }
 
     /// Drop the guard without calling [`Semaphore::release`]. This is useful when `release`s don't
@@ -138,7 +138,7 @@ impl SemaphoreGuardArc {
         let sem2 = other.semaphore.as_ref().unwrap();
         assert!(Arc::ptr_eq(sem1, sem2),
             "Can't extend a guard with a guard from a different Semaphore");
-        self.amount += other.forget();
+        self.amount = self.amount.saturating_add(other.forget());
     }
 
     /// Drop the guard without calling [`Semaphore::release`]. This is useful when `release`s don't

--- a/src/state.rs
+++ b/src/state.rs
@@ -37,6 +37,17 @@ pub(crate) enum AcquireState {
     Available(Permits),
 }
 
+impl AcquireState {
+    #[cfg(test)]
+    pub(crate) fn available(&self) -> Option<usize> {
+        if let Available(permits) = self {
+            permits.into_usize()
+        } else {
+            None
+        }
+    }
+}
+
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
 pub enum AcquireStep {
     // The future was just created

--- a/src/tests/unit.rs
+++ b/src/tests/unit.rs
@@ -155,16 +155,13 @@ fn test_extend_overflow() {
 
 // Atempting to combine guards from different semaphores should poison both
 #[test]
+#[should_panic(expected = "Can't extend a guard with a guard from a different Semaphore")]
 fn test_extend_wrong_sems() {
     let semaphore1 = Semaphore::new(15);
     let semaphore2 = Semaphore::new(15);
     let mut g1 = TestFuture::new(&semaphore1, 10).poll().unwrap().unwrap();
     let g2 = TestFuture::new(&semaphore2, 5).poll().unwrap().unwrap();
     g1.extend(g2);
-    drop(g1);
-    // At this point, both semaphores should be poisoned
-    TestFuture::new(&semaphore1, 1).poll().unwrap().err().unwrap();
-    TestFuture::new(&semaphore2, 1).poll().unwrap().err().unwrap();
 }
 
 #[test]
@@ -181,16 +178,13 @@ fn test_extend_arc() {
 }
 
 #[test]
+#[should_panic(expected = "Can't extend a guard with a guard from a different Semaphore")]
 fn test_extend_arc_wrong_sems() {
     let semaphore1 = Arc::new(Semaphore::new(15));
     let semaphore2 = Arc::new(Semaphore::new(15));
     let mut g1 = semaphore1.acquire_arc(10).now_or_never().unwrap().unwrap();
     let g2 = semaphore2.acquire_arc(5).now_or_never().unwrap().unwrap();
     g1.extend(g2);
-    drop(g1);
-    // At this point, both semaphores should be poisoned
-    assert!(semaphore1.acquire_arc(1).now_or_never().unwrap().is_err());
-    assert!(semaphore2.acquire_arc(1).now_or_never().unwrap().is_err());
 }
 
 // Attempting to combine guards will poison the semaphores if the permits would overflow


### PR DESCRIPTION
extend allows combining two guards into one, with the combined number of
permits.

split allows splitting one guard into two, with a selectable division of
permits.

Fixes #1